### PR TITLE
Hyperlink DOI against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Note the different I2C-addresses, calculations and correction functions between 
 The examples nicely show how to use this library with the standard MS5xxx-class. For usage with MS5611 chips just use the class MS5611 in the same way.
 "Standard units" are Pascals for pressure and 0.01 °C for temperature as calculations are done exactly as shown in the manufacturers datasheet.
 
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.47085.svg)](http://dx.doi.org/10.5281/zenodo.47085)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.47085.svg)](https://doi.org/10.5281/zenodo.47085)
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Zenodo uses it as well for new badges ;-)

Cheers!